### PR TITLE
add 'clean' command with a cute alias 'wash'

### DIFF
--- a/src/python/mshields/chaps/chaps.py
+++ b/src/python/mshields/chaps/chaps.py
@@ -29,6 +29,10 @@ If you're looking to resolve formatting issues, look no more for the fmt goal:
 
   $ chaps fmt :target
 
+If you need to clean up after Pants, try out the clean command:
+
+  $ chaps clean
+
 Note: chaps only works with targets in your current work directory (cwd).  Fall
 back to calling pants directly if you need something else.
 """
@@ -113,11 +117,12 @@ def run_goal(args):
   pants_args = "run {0} {1}".format(targets, run_args)
   lib.pants(pants_args)
 
+
 @app.command(name="clean")
 @app.command(name="clean-all")
 @app.command(name="wash")
 def clean_goal(args):
-  """Clean pants from anywhere in the tree."""
+  """Clean pants."""
 
   log.debug("chaps clean")
   lib.pants("clean-all")

--- a/src/python/mshields/chaps/chaps.py
+++ b/src/python/mshields/chaps/chaps.py
@@ -130,7 +130,7 @@ def clean_goal(args):
 
 @app.command_option(
   "--all", action="store_true", dest="all", default=False,
-  help="Test all targets in path name simliar to cwd.",
+  help="Test all targets in path name similar to cwd.",
 )
 @app.command_option(
   "--coverage", action="store_true", dest="coverage", default=False, help="Python test coverage.",

--- a/src/python/mshields/chaps/chaps.py
+++ b/src/python/mshields/chaps/chaps.py
@@ -113,6 +113,15 @@ def run_goal(args):
   pants_args = "run {0} {1}".format(targets, run_args)
   lib.pants(pants_args)
 
+@app.command(name="clean")
+@app.command(name="clean-all")
+@app.command(name="wash")
+def clean_goal(args):
+  """Clean pants from anywhere in the tree."""
+
+  log.debug("chaps clean")
+  lib.pants("clean-all")
+
 
 @app.command_option(
   "--all", action="store_true", dest="all", default=False,


### PR DESCRIPTION
### Problem

it would be nice to be able to do `a ./pants clean-all` from anywhere in the tree.

### Solution

Added `chaps clean`, `chaps clean-all`, and `chaps wash` commands.

### Result

You can now `chaps wash` from deep inside a pants-enabled repo.